### PR TITLE
Fix CLI tooling not matching latest edition of pakk API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,42 @@ Encrypt and pack several files or folders into a single invokable file.
 
 This package comes equipped with a CLI tool and a simple library for working with pakk files. See the sections below regarding each.
 
+## Getting Started
+
+Pakk is built to work on Python 3.6 and above.
+
+Install:
+```sh
+$ python3 -m pip install pakk
+```
+
+Using the CLI:
+```sh
+# pakk 'somefile.txt' and all the files in './somefolder' into 'files.pakk'
+# encrypting with the password 'kitty'
+$ pakk pakk -o files.pakk -p kitty somefile.txt ./somefolder
+
+# unpakk 'files.pakk' into all the original files
+$ pakk unpakk -o . -p kitty files.pakk
+```
+
+Using the library:
+```py
+import hashlib
+import pakk
+
+# encrypt with the password 'kitty'
+password = "kitty"
+key = hashlib.sha256(password.encode("utf-8")).digest()
+
+# pakk 'somefile.txt' and all the files in './somefolder' into 'files.pakk'
+with open("./files.pakk", "wb") as out_file:
+    pakk_files(key, ["files.pakk", "./somefolder"], out_file)
+
+# unpakk `files.pakk` into all the original files
+unpakk_files(key, "./files.pakk")
+```
+
 ## CLI
 
 The pakk CLI tool has two subcommands: `pakk` and `unpakk`. Here are their help outputs:
@@ -68,30 +104,30 @@ pakk provides a [few functions and types](#API) for working with pakk buffers an
 
 Keys should be AES-compatible and are typically bytes-like objects:
 ```py
-    import hashlib
+import hashlib
 
-    password = "kitty"
-    key = hashlib.sha256(password.encode("utf-8")).digest()
+password = "kitty"
+key = hashlib.sha256(password.encode("utf-8")).digest()
 ```
 
 You can pakk a single file using `pakk_files`:
 ```py
-    with open("./outputfile.pakk", "wb") as out_file:
-        pakk_files(key, ["./some/file"], out_file)
+with open("./outputfile.pakk", "wb") as out_file:
+    pakk_files(key, ["./some/file"], out_file)
 ```
 
 And to unpakk back into files, use `unpakk_files`:
 ```py
-    unpakk_files(key, "./outputfile.pakk")
+unpakk_files(key, "./outputfile.pakk")
 ```
 
 If you want to invoke a pakks file without unpakking it into the original file structure, use `unpakk`:
 ```py
-    with open("./outputfile.pakk", "rb") as in_file:
-        pakk = unpakk(key, in_file)
+with open("./outputfile.pakk", "rb") as in_file:
+    pakk = unpakk(key, in_file)
 
-    for key, blob in pakk.blobs.items():
-        print(f"{key}: {blob.name}")
+for key, blob in pakk.blobs.items():
+    print(f"{key}: {blob.name}")
 ```
 
 ### API

--- a/bin/pakk
+++ b/bin/pakk
@@ -5,7 +5,7 @@ CLI tool for building Pakks from folders.
 
 import hashlib
 from argparse import ArgumentParser
-import pakk as pakker
+from pakk import pakk_files, unpakk_files
 
 if __name__ == "__main__":
 
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         argument("-o", "--output", dest="output", help="output path of the pakk file."),
         argument("-p", "--password", dest="password", help="password used to encrypt the contents of the pakk. Defaults to 'IsPakked'. It is HIGHLY recommended that you supply your own secure password with high entropy for each pakk.", default="IsPakked", type=str),
         argument("-c", "--chunksize", dest="chunksize", help="maximum amount of bytes to encrypt at once when pakking files in the folder. Must be an integer multiple of 1024. Defaults to 64*1024", default=64*1024, type=int),
-        argument("input", help="input folder to encrypt and pakk."),
+        argument("input", help="input files and folders to encrypt and pakk."),
     ])
     def pakk(args):
         """
@@ -36,7 +36,9 @@ if __name__ == "__main__":
         if args.chunksize % 1024 != 0:
             CLI.error("--chunksize must be a multiple of 1024")
         key = hashlib.sha256(args.password.encode("utf-8")).digest()
-        pakker.pakk_folder(key=key, folder=args.input, outfile=args.output, chunksize=args.chunksize)
+        if not isinstance(args.input, list):
+            args.input = [args.input]
+        pakk_files(key=key, files=args.input, destination=args.output, chunksize=args.chunksize)
 
     @subcommand(args=[
         argument("-o", "--output", dest="output", help="path of the folder to output the pakk contents to."),
@@ -51,7 +53,7 @@ if __name__ == "__main__":
         if args.chunksize % 1024 != 0:
             CLI.error("--chunksize must be a multiple of 1024")
         key = hashlib.sha256(args.password.encode("utf-8")).digest()
-        pakker.unpakk_folder(key=key, pakk_file=args.input, outfolder=args.output, chunksize=args.chunksize)
+        unpakk_files(key=key, file=args.input, destination=args.output, chunksize=args.chunksize)
 
     def main():
         args = CLI.parse_args()

--- a/pakk/__init__.py
+++ b/pakk/__init__.py
@@ -369,7 +369,6 @@ def pakk_files(key, files: List[str], destination: Union[io.BufferedIOBase, str]
                     chunk += b"\x00" * (16 - len(chunk) % 16)
 
                 encrypted = encryptor.encrypt(chunk)
-                print(f"expected bytes for {filename}: {encrypted}")
                 out_file.write(encrypted)
 
     if isinstance(destination, str):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name="pakk",
-    version="0.1.1",
+    version="1.0.0",
     author="Tristen Horton",
     author_email="tristen@tristenhorton.com",
     description="A package for encrypting and packing files into a single uncompressed file.",


### PR DESCRIPTION
## Breaking Change
The changes listed below cause an incompatibility with the latest version of pakk. The major version will be incremented to reflect this.

## Changes
- CLI Tool now uses `pakk_files` and `unpakk_files`, as the `_folders` variants were deprecated and removed in a pre-release version. 
- old debug info is no longer printed out in pakk_files.
- added some simple getting started examples to README.md
- incremented major version